### PR TITLE
Use bower.json instead of component.json

### DIFF
--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -65,10 +65,10 @@ module BowerRails
       dependencies_to_json @dependencies[normalize_location_path(location)]
     end
 
-    def write_components_js
+    def write_bower_json
       @dependencies.each do |dir,data|
         FileUtils.mkdir_p dir unless File.directory? dir
-        File.open(File.join(dir,"component.json"),"w") do |f|
+        File.open(File.join(dir,"bower.json"),"w") do |f|
           f.write(dependencies_to_json(data))
         end
       end

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -42,8 +42,8 @@ def dsl_perform_command remove_components = true
   dsl = BowerRails::Dsl.evalute(Rails.root.join("Jsfile"))
   
   if remove_components  
-    dsl.write_components_js 
-    puts "component.js files generated"
+    dsl.write_bower_json
+    puts "bower.js files generated"
   end
   
   dsl.directories.each do |dir|
@@ -72,16 +72,16 @@ def perform_command remove_components = true
       #remove old components
       FileUtils.rm_rf("components") if remove_components
 
-      #create component json
-      File.open("component.json","w") do |f|
+      #create bower json
+      File.open("bower.json","w") do |f|
         f.write(data.to_json)
       end
 
       #run command
       yield
 
-      #remove component file
-      FileUtils.rm("component.json")
+      #remove bower file
+      FileUtils.rm("bower.json")
 
     end if data
 

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -4,4 +4,4 @@ BowerRails::Dsl.config = {:root_path => File.expand_path("./out") }
 
 inst = BowerRails::Dsl.evalute(File.expand_path("./Jsfile.rb"))
 
-inst.write_components_js
+inst.write_bower_json


### PR DESCRIPTION
Because latest bower output warnings `warn Using deprecated "component.json". Please use "bower.json" instead`
