### PR TITLE
Add support for bower 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,17 @@ bower-rails
 
 rake tasks for bower on rails. Dependency file is bower.json in Rails root dir.
 
-**Asset Pipeline**
-
-As of version 0.3.0 bower-rails installs components in the asset directory, rather than assets/javascripts. This is because some of these packages also include stylesheets, or images. As such you may have to add components to your asset pipeline.
-
-``` Ruby
-  # config/application.rb
-
-  config.assets.paths << Rails.root.join("lib", "assets", "components")
-  config.assets.paths << Rails.root.join("vendor", "assets", "components")
-```
-
 **Requirements**
 
 * [node](http://nodejs.org) ([on github](https://github.com/joyent/node))
-* [bower](https://github.com/bower/bower) (>= 0.9) installed with npm
+* [bower](https://github.com/bower/bower) (>= 0.10.0) installed with npm
 
 **Install**
 
 in Gemfile
 
 ``` Ruby
-	gem "bower-rails", "~> 0.3.2"
+	gem "bower-rails", "~> 0.4.0"
 ```
 
 **Initialize**
@@ -44,14 +33,16 @@ The bower.json file is two seperate bower [component.js](https://github.com/twit
 ``` javascript
 {
    "lib": {
+    "name": "bower-rails generated lib assets",
     "dependencies": {
       "threex"      : "git@github.com:rharriso/threex.git",
       "gsvpano.js"  : "https://github.com/rharriso/GSVPano.js/blob/master/src/GSVPano.js"
     }
   },
   "vendor": {
+    "name": "bower-rails generated vendor assets",
     "dependencies": {
-      "three.js"  : "https://raw.github.com/mrdoob/three.js/master/build/three.js"
+      "three.js"    : "https://raw.github.com/mrdoob/three.js/master/build/three.js"
     }
   }
 }

--- a/bower-rails.gemspec
+++ b/bower-rails.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = "bower-rails"
   s.homepage      = "https://github.com/rharriso/bower-rails"
-  s.version       = "0.3.3"
+  s.version       = "0.4.0"
   s.date          = "2013-05-08"
   s.summary       = "Bower for Rails"
   s.description   = "Bower for Rails"

--- a/lib/bower-rails/railtie.rb
+++ b/lib/bower-rails/railtie.rb
@@ -6,7 +6,7 @@ module BowerRails
 
     config.after_initialize do |app|
       ["lib", "vendor"].each do |dir|
-        app.config.assets.paths << Rails.root.join(dir, 'assets', 'components')
+        app.config.assets.paths << Rails.root.join(dir, 'assets', 'bower_components')
       end
     end
 

--- a/lib/generators/bower_rails/initialize/templates/bower.json
+++ b/lib/generators/bower_rails/initialize/templates/bower.json
@@ -1,9 +1,11 @@
 {
   "lib": {
+    "name": "bower-rails generated lib assets",
     "dependencies": {
     }
   },
   "vendor": {
+    "name": "bower-rails generated vendor assets",
     "dependencies": {
     }
   }

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -80,7 +80,7 @@ def perform_command remove_components = true
     Dir.chdir(dir) do
 
       #remove old components
-      FileUtils.rm_rf("components") if remove_components
+      FileUtils.rm_rf("bower_components") if remove_components
 
       #create bower json
       File.open("bower.json","w") do |f|


### PR DESCRIPTION
Tested for 0.10.0 and 1.0.0. Please let me know if you don't want the version bump in this commit. Thanks!
- default path changed to bower_components since 0.10.0
- name is now a required field in bower.json since 1.0.0
