### PR TITLE
Development "fix" when going to a previous component version - but this is probably not best way to address

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -90,6 +90,9 @@ def perform_command remove_components = true
       #run command
       yield
 
+      #touch everything to shake up the rails asset cache, in case we are going to prev version
+      FileUtils.touch(Dir.glob('**'));
+
       #remove bower file
       FileUtils.rm("bower.json")
 


### PR DESCRIPTION
Hi - I wanted to submit this in case you wanted to consider this use case:

In development the sprockets cache will not pick up the most recently installed component version for the following scenario:
1) Install any component say version 1.0.5
2) Utilize component from local rails server
3) Now update the version of that component in bower.json to 1.0.4 and run the bower:update rake task
4) The previous version of component is installed correctly, but the rails server will still serve the 1.0.5 version because the date/time of the 1.0.4 is older than what sprockets has cached.

So though this isn't a problem with your gem (its just the way asset cache works) - it could be nice to provide a workaround for this by busting the cache.

I submitted a brute force "touch" of the entire component directory on update, but I figured there might be a better way to accomplish this.

Just thought I'd bring this to your attention.  Thanks!
