### PR TITLE
Prune option for 'update' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The bower.json file is two seperate bower [component.js](https://github.com/twit
 
 ``` bash
   rake bower:install #install js components
-  rake bower:update  #update js components
+  rake bower:install:force #install with force option
+  rake bower:update #update js components
+  rake bower:update:prune #update components and uninstall extraneous packages
 ```
 
 
@@ -105,7 +107,9 @@ NOTE: All the assets should be stored in `/assets` subdirectory so putting it un
 
 ``` bash
   rake bower:dsl:install #install js components
-  rake bower:dsl:update  #update js components
+  rake bower:dsl:install:force #install with force option
+  rake bower:dsl:update #update js components
+  rake bower:dsl:update:prune #update components and uninstall extraneous packages
 ```
 
 

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -1,8 +1,9 @@
 require 'json'
 require 'pp'
+
 namespace :bower do
 
-  desc "install files from bower"
+  desc "install components from bower"
   task :install do
     #install to corresponding directories
     perform_command do
@@ -11,6 +12,7 @@ namespace :bower do
   end
 
   namespace :install do
+    desc "install components with -F option"
     task :force do
       perform_command do
         sh 'bower install -F'
@@ -18,7 +20,7 @@ namespace :bower do
     end
   end
 
-  desc "update bower packages"
+  desc "update bower components"
   task :update do
     #install to corresponding directories
     perform_command false do
@@ -26,8 +28,17 @@ namespace :bower do
     end
   end
 
+  namespace :update do
+    desc "update existing components and uninstalls extraneous components"
+    task :prune do
+      perform_command false do
+        sh 'bower update && bower prune'
+      end
+    end
+  end
+
   namespace :dsl do
-    desc "install files from bower"
+    desc "install components from bower"
     task :install do
       #install to corresponding directories
       dsl_perform_command do
@@ -35,14 +46,34 @@ namespace :bower do
       end
     end
 
-    desc "update bower packages"
+    namespace :install do
+      desc "install components with -F option"
+      task :force do
+        dsl_perform_command do
+          sh 'bower install -F'
+        end
+      end
+    end
+
+    desc "update bower components"
     task :update do
       #install to corresponding directories
       dsl_perform_command false do
         sh 'bower update'
       end
     end
+
+    namespace :update do
+      desc "update existing components and uninstalls extraneous components"
+      task :prune do
+        dsl_perform_command false do
+          sh 'bower update && bower prune'
+        end
+      end
+    end
+    
   end
+
 end
 
 def get_bower_root_path


### PR DESCRIPTION
- Added extra 'prune' task. Useful when bower-rails configuration file
  is changed and we want to keep bower_components directory clean after
  running "bower update" task. Note: available only with bower >= 1.1.2
- Added 'force' task to "dsl:install" namespace
- Common name convention in tasks description
