### PR TITLE
Make .bowerrc location relative to current Rails.root.

### DIFF
--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -65,7 +65,8 @@ module BowerRails
 
     def write_dotbowerrc
       @groups.map do |g|
-        File.open(File.join(g.first.to_s, group_assets_path(g), ".bowerrc"), "w") do |f|
+        g_norm = normalize_location_path(g.first, group_assets_path(g))
+        File.open(File.join(g_norm, ".bowerrc"), "w") do |f|
           f.write(JSON.pretty_generate({:directory => "bower_components"}))
         end
       end


### PR DESCRIPTION
It actually had been done for bower.json. In my case bower-rails is used in engine which is stored with main app. During bower:install and attempt to write .bowerrc paths was broken.
