### PR TITLE
Use root .bowerrc as starting point, rather than creating one from scratch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,8 +3,8 @@
 * `rake bower:list` task now available
 * There is no more `dsl` namespace for rake tasks. Tasks are the same as for `bower.json` also for `Bowerfile` configuration files.
 * Add support for standard bower package format by @kenips ([#41][])
-
 [#41]: https://github.com/42dev/bower-rails/pull/41
+* If a `.bowerrc` file is available in the rails project root, it will now be used as the starting point for the generated `.bowerrc`.
 
 ## v0.5.0
 * Jsfile was renamed to Bowerfile and BowerRails::Dsl#js to BowerRails::Dsl#asset ([discussion][])

--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ Once you are done with `bower.json` or `Bowerfile` you can run
 * `rake bower:update` to update js components
 * `rake bower:update:prune` to update components and uninstall extraneous packages
 * `rake bower:list` to list all packages
+
+##Bower Configuration
+
+If you provide a `.bowerrc` in the rails project root, bower-rails will use it for bower configuration.
+Some .bowerrc options are not supported: `directory`, `cwd`, and `interactive`. Bower-rails
+will ignore the `directory` property and instead will use the automatically generated asset path.

--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -53,11 +53,16 @@ module BowerRails
       end
     end
 
+    def generate_dotbowerrc
+      contents = JSON.parse(File.read(File.join(@root_path, '.bowerrc'))) rescue {}
+      contents["directory"] = "bower_components"
+    end
+
     def write_dotbowerrc
       groups.map do |g|
         g_norm = normalize_location_path(g.first, group_assets_path(g))
         File.open(File.join(g_norm, ".bowerrc"), "w") do |f|
-          f.write(JSON.pretty_generate({:directory => "bower_components"}))
+          f.write(JSON.pretty_generate(generate_dotbowerrc))
         end
       end
     end

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -87,6 +87,11 @@ def perform_command remove_components = true, &block
   txt  = File.read(File.join(bower_root, "bower.json"))
   json = JSON.parse(txt)
 
+
+  #load and merge root .bowerrc
+  dot_bowerrc = JSON.parse(File.read(File.join(bower_root, '.bowerrc'))) rescue {}
+  dot_bowerrc["directory"] = "bower_components"
+
   folders = ["vendor"]
   folders << "lib" if !!json["lib"]
 
@@ -113,7 +118,7 @@ def perform_command remove_components = true, &block
 
       #create .bowerrc
       File.open(".bowerrc", "w") do |f|
-        f.write(JSON.pretty_generate({:directory => "bower_components"}))
+        f.write(JSON.pretty_generate(dot_bowerrc))
       end
 
       #run command


### PR DESCRIPTION
In the case where a custom .bowerrc is needed, for example, with custom registries, it seemed that bower-rails was ignoring .bowerrc in the rails root directory, and generating a new .bowerrc per group. This loses any required settings. I didn't see any other way to set registries in bower-rails.

This PR reads the root .bowerrc, and merges in the "bower_components" directory to create the new generated .bowerrc files.
