### PR TITLE
A better check for bower.json formats.

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -88,10 +88,15 @@ def perform_command remove_components = true, &block
   dot_bowerrc = JSON.parse(File.read(File.join(bower_root, '.bowerrc'))) rescue {}
   dot_bowerrc["directory"] = "bower_components"
 
-  folders = ["vendor"]
-  folders << "lib" if !!json["lib"]
+  if json.except('lib', 'vendor').empty?
+    folders = json.keys
+  else
+    raise "Assuming a standard bower package but cannot find the required 'name' key" unless !!json['name']
+    folders = ['vendor']
+  end
 
   folders.each do |dir|
+    puts "\nInstalling dependencies into #{dir}"
 
     data = json[dir]
 


### PR DESCRIPTION
Previous commit to support standard bower.json breaks lib only variations of bower.json as reported in https://github.com/42dev/bower-rails/pull/41#issuecomment-28333032. This commit makes the detection more robust.
