### PR TITLE
Fix relative URLs in bower components

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -49,6 +49,9 @@ namespace :bower do
   end
 end
 
+# Install bower assets before precompile
+Rake::Task['assets:precompile'].enhance ['bower:install', 'bower:resolve']
+
 def perform remove_components = true, &block
   entries = Dir.entries(get_bower_root_path)
 


### PR DESCRIPTION
There are many bower components with CSS files that have relative image URLs in them. For example, Bootstrap 2, jQuery UI, and JCrop all do this. This is fine in development, but when the assets are compiled with `rake assets:precompile`, the links to these images break. This is why Rails has [special helpers](http://guides.rubyonrails.org/asset_pipeline.html#coding-links-to-assets) for asset links.

I have created a `bower:resolve` task to replace all relative paths to an `asset_path` call. This way all CSS files in bower components will work in both development and production.
