### PR TITLE
bower:resolve task fail when component's name contains ".css"

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -163,7 +163,7 @@ end
 def resolve_asset_paths
   # Resolve relative paths in CSS
   Dir['bower_components/**/*.css'].each do |filename|
-    contents = File.read(filename)
+    contents = File.read(filename) if FileTest.file?(filename)
     # http://www.w3.org/TR/CSS2/syndata.html#uri
     url_regex = /url\(\s*['"]?(?![a-z]+:)([^'"\)]*)['"]?\s*\)/
 


### PR DESCRIPTION
`bower:resolve` task fail when component's name contains ".css"
('animate.css', 'hint.css', ...)

``` ruby
rake aborted!
Is a directory @ io_fread - bower_components/hint.css
```

I patched `FileTest.file?` to skip that case, but I think there is a more smarter approach.
