### PR TITLE
update github examples to match the working code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ By default assets are put to `./vendor/assets/bower_components` directory:
 # Puts to ./vendor/assets/bower_components
 asset "backbone"
 asset "moment", "2.0.0" # get exactly version 2.0.0
-asset "secret_styles", "git@github:initech/secret_styles" # get from a git repo
+asset "secret_styles", "git@github.com:initech/secret_styles" # get from a git repo
 # get from a git repo using the tag 1.0.0
-asset "secret_logic", "1.0.0", git: "git@github:initech/secret_logic"
+asset "secret_logic", "1.0.0", git: "git@github.com:initech/secret_logic"
 # short-hand for
-# asset "secret_logic", "git@github:initech/secret_logic#1.0.0"
+# asset "secret_logic", "git@github.com:initech/secret_logic#1.0.0"
 ```
 
 But the default value can be overridden by `assets_path` method:


### PR DESCRIPTION
I was getting errors like this:

```
bower fluidbox#*               ECMDERR Failed to execute "git ls-remote --tags --heads git@github:hybernaut/Fluidbox", exit code of #128

Additional error details:
ssh: Could not resolve hostname github: nodename nor servname provided, or not known
fatal: Could not read from remote repository.
```

and it turns out the Bowerfile examples should use "git@github.com" instead of "git@github"
