### PR TITLE
Ensuring executable command doesn't point to a directory

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -229,7 +229,7 @@ def find_command(cmd, paths = [])
   paths.each do |path|
     exts.each do |ext|
       exe = File.join(path, "#{cmd}#{ext}")
-      return exe if File.executable? exe
+      return exe if (File.executable?(exe) && File.file?(exe))
     end
   end
   nil


### PR DESCRIPTION
Ensuring executable command is not only executable as per Ruby's File class but also an actual file (and not a directory). My bower:update rake task was failing because it was pointing to the bower directory in one of my exec paths and not to the actual executable file. Turns out File.executable? returns true for directories too if they have the right permissions.
