### PR TITLE
Add github option to DSL.

### DIFF
--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -26,16 +26,21 @@ module BowerRails
 
     def group(name, options = {}, &block)
       options[:assets_path] ||= @assets_path
-      
+
       assert_asset_path options[:assets_path]
       assert_group_name name
-      
+
       @current_group = add_group name, options
       yield if block_given?
     end
 
-    def asset(name, version = "latest", options={})
-      group = @current_group ? @current_group : default_group
+    def asset(name, *args)
+      group = @current_group || default_group
+
+      options = Hash === args.last ? args.pop.dup : {}
+      version = args.last || "latest"
+
+      options[:git] = "git://github.com/#{options[:github]}" if options[:github]
 
       if options[:git]
         version = if version == 'latest'
@@ -78,7 +83,7 @@ module BowerRails
       groups.map do |group|
         [group.first.to_s, group_assets_path(group)]
       end
-    end   
+    end
 
     def group_assets_path group
       group.last[:assets_path]

--- a/spec/bower-rails/dsl_spec.rb
+++ b/spec/bower-rails/dsl_spec.rb
@@ -55,6 +55,16 @@ describe BowerRails::Dsl do
       subject.asset :new_hotness, "1.2.3", :git => "git@github.com:initech/tps-kit"
       subject.dependencies.values.should include :new_hotness => "git@github.com:initech/tps-kit#1.2.3"
     end
+
+    it "should accept a github path" do
+      subject.asset :new_hotness, :github => "initech/tps-kit"
+      subject.dependencies.values.should include :new_hotness => "git://github.com/initech/tps-kit"
+    end
+
+    it "should accept a github path and a version and put it all together" do
+      subject.asset :new_hotness, "1.2.3", :github => "initech/tps-kit"
+      subject.dependencies.values.should include :new_hotness => "git://github.com/initech/tps-kit#1.2.3"
+    end
   end
 
   it "should have a private method to validate asset paths" do
@@ -75,6 +85,6 @@ describe BowerRails::Dsl do
     it "should set the default group with custom assets_path" do
       subject.send :assets_path, "assets/somepath"
       subject.send(:default_group).should eq [:vendor, { :assets_path => "assets/somepath" }]
-    end 
+    end
   end
 end


### PR DESCRIPTION
This adds the ability to use a Bundler-style github option:

``` ruby
asset "foo", github: "xtian/foo"
asset "foo", "1.2.3", github: "xtian/foo"
```
