### PR TITLE
Add ability to specify SHA option for git endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Edge version
 
+* DSL: Add ability to specify `ref` option which accepts commit's SHA and composes it as a component's version
+
 ## v0.7.2
 
 * add configurable option for performing `rake bower:install` and `rake bower:clean` tasks before assets precompilation

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ asset "secret_logic", "1.0.0", git: "git@github.com:initech/secret_logic"
 
 # get from a github repo
 asset "secret_logic", "1.0.0", github: "initech/secret_logic"
+
+# get a specific revision from a git endpoint 
+asset "secret_logic", github: "initech/secret_logic", ref: '0adff'
 ```
 
 But the default value can be overridden by `assets_path` method:

--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -36,9 +36,10 @@ module BowerRails
 
     def asset(name, *args)
       group = @current_group || default_group
-
       options = Hash === args.last ? args.pop.dup : {}
+
       version = args.last || "latest"
+      version = options[:ref] if options[:ref]
 
       options[:git] = "git://github.com/#{options[:github]}" if options[:github]
 

--- a/spec/bower-rails/dsl_spec.rb
+++ b/spec/bower-rails/dsl_spec.rb
@@ -65,6 +65,21 @@ describe BowerRails::Dsl do
       subject.asset :new_hotness, "1.2.3", :github => "initech/tps-kit"
       subject.dependencies.values.should include :new_hotness => "git://github.com/initech/tps-kit#1.2.3"
     end
+
+    it "should accept a ref option and set it as a version" do
+      subject.asset :new_hotness, :ref => "b122a"
+      subject.dependencies.values.should include :new_hotness => "b122a"
+    end
+
+    it "should accept a git and ref option and put it all together" do
+      subject.asset :new_hotness, :git => "git@github.com:initech/tps-kit", :ref => "b122a"
+      subject.dependencies.values.should include :new_hotness => "git@github.com:initech/tps-kit#b122a"
+    end  
+
+    it "should accept a github and ref option and put it all together" do
+      subject.asset :new_hotness, :github => "initech/tps-kit", :ref => "b122a"
+      subject.dependencies.values.should include :new_hotness => "git://github.com/initech/tps-kit#b122a"
+    end     
   end
 
   it "should have a private method to validate asset paths" do


### PR DESCRIPTION
Like `asset 'asset-name', git: '...', sha: 'a45fde12'`

https://github.com/42dev/bower-rails/issues/80
