### PR TITLE
Add install task which uses generated bower.json

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -13,6 +13,16 @@ namespace :bower do
     end
   end
 
+  namespace :install do
+    desc "Install components from bower using previously generated bower.json"
+    task :deployment, :options do |_, args|
+      args.with_defaults(:options => '')
+      perform false do |bower|
+        sh "#{bower} install #{args[:options]}"
+      end
+    end
+  end
+
   desc "Update bower components"
   task :update, :options do |_, args|
     args.with_defaults(:options => '')


### PR DESCRIPTION
Hi, this request add task to install libraries using already generated bower.json. It's usefull when you deploying to production. Cause `bower.json` also includes resolutions which erased bu original `bower:install` task. 
