### PR TITLE
Fix "undefined method 'perform' for main:Object" caused by merging #93.

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -24,13 +24,13 @@ namespace :bower do
     desc "Install both dependencies and devDependencies from bower"
     task :development, :options do |_, args|
       args.with_defaults(:options => '')
-      perform{ |bower| sh "#{bower} install #{args[:options]}" }
+      BowerRails::Performer.perform{ |bower| sh "#{bower} install #{args[:options]}" }
     end
 
     desc "Install only dependencies, excluding devDependencies from bower"
     task :production, :options do |_, args|
       args.with_defaults(:options => '')
-      perform{ |bower| sh "#{bower} install -p #{args[:options]}" }
+      BowerRails::Performer.perform{ |bower| sh "#{bower} install -p #{args[:options]}" }
     end
   end
 


### PR DESCRIPTION
Fix "undefined method 'perform' for main:Object" caused by merging #93.

```
NoMethodError: undefined method `perform' for main:Object
vendor/bundle/ruby/2.1.0/gems/bower-rails-0.8.1/lib/tasks/bower.rake:33:in `block (3 levels) in <top (required)>'`
```
