### PR TITLE
issue resolving url when url begins with #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Edge version
 
+* do not resolve urls which start with '#' #102
+
 ## v0.8.3
 
 * add `use_bower_install_deployment` configurable option by @Zhomart [#101][]

--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -120,7 +120,7 @@ module BowerRails
       Dir['bower_components/**/*.css'].each do |filename|
         contents = File.read(filename) if FileTest.file?(filename)
         # http://www.w3.org/TR/CSS2/syndata.html#uri
-        url_regex = /url\(\s*['"]?(?![a-z]+:)([^'"\)]*)['"]?\s*\)/
+        url_regex = /url\((?!\#)\s*['"]?(?![a-z]+:)([^'"\)]*)['"]?\s*\)/
 
         # Resolve paths in CSS file if it contains a url
         if contents =~ url_regex


### PR DESCRIPTION
The url resolver needs to be changed so it doesn't change urls that begin with a #

I've been running into an issue with trying to use bower-rails when using mapbox.js, 

they include a work around for IE8 clients in their css that has 

``` css
behavior:url(#default#VML);
```

when the resolver runs it sees that and gets turned into 

``` css
behavior:url(asset_path 'mapbox.js/#default#VML')
```

which then causes sprockets to fail because it can't find a file 'mapbox.js/' (#default#VML gets stripped out by sprockets), if I manually edit the generated erb file and change that line back to the original url(#default#VML) everything works fine and compiles.

The file in question is here:
https://github.com/gina-alaska/mapbox-dist/blob/master/mapbox.uncompressed.css#L767

Small rails app that demonstrates the problem
https://github.com/teknofire/test-bower-rails
