### PR TITLE
Rename `BeforeHook#before` to `before_rake_task` to avoid conflict

### DIFF
--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -79,7 +79,7 @@ namespace :bower do
   end
 end
 
-before 'assets:precompile' do
+before_rake_task 'assets:precompile' do
   BowerRails.tasks.map do |task|
     Rake::Task[task].invoke
   end

--- a/lib/tasks/helpers/before_hook.rb
+++ b/lib/tasks/helpers/before_hook.rb
@@ -1,7 +1,7 @@
 module BeforeHook
-  # The `before` hook for rake tasks. 
+  # The `before` hook for rake tasks.
   # The code was taken from https://github.com/guillermo/rake-hooks/blob/master/lib/rake/hooks.rb#L2
-  def before(*task_names, &new_task)
+  def before_rake_task(*task_names, &new_task)
     task_names.each do |task_name|
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name.to_s)
       return unless old_task


### PR DESCRIPTION
If you have `sinatra` and `sinatra-assetpack` in your Gemfile together with `bower-rails`, it will conflict with this method name `before`, causing bower-rails hook tasks to not run at all.

If you try to setup a brand new Rails app with the `sidekiq-benchmark` (0.4.1 at the moment), you will be able to reproduce this bug.
