### PR TITLE
Update bower configuration file to match readme

### DIFF
--- a/lib/generators/bower_rails/initialize/templates/bower_rails.rb
+++ b/lib/generators/bower_rails/initialize/templates/bower_rails.rb
@@ -10,4 +10,7 @@ BowerRails.configure do |bower_rails|
 
   # Invokes rake bower:clean before precompilation. Defaults to false
   # bower_rails.clean_before_precompile = true
+  
+  # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
+  # bower_rails.use_bower_install_deployment = true
 end


### PR DESCRIPTION
It was missing the last line from [Configuration.](https://github.com/42dev/bower-rails/tree/92a85cdc16e4e51d0c4561b6f7eb3aa63dbcf340#configuration)
