### PR TITLE
In README, fix dependency_group :dev_dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ And finally, you can specify the assets to be in the devDependencies block:
 asset "backbone", "1.1.1"
 
 # Adds jasmine-sinon and jasmine-matchers to devDependencies
-dependency :dev_dependencies  do
+dependency_group :dev_dependencies  do
   asset "jasmine-sinon"            # Defaults to 'latest'
   asset "jasmine-matchers"         # Defaults to 'latest'
 end


### PR DESCRIPTION
Not sure if this was intended, but I had to use `dependency_group` instead of `dependency` to get the `:dev_dependencies` to work in `Bowerfile`.
