### PR TITLE
Add ability to configure bower to force install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Edge version
 
+* add ability to configure bower to pass -F to bower install by @hubert [#129][]
+
+[#121]: https://github.com/42dev/bower-rails/pull/129
+
 ## v0.9.2
 
 * remove before hook in favour of rake dependency by @itszootime and @carsomyr [#121][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * add ability to configure bower to pass -F to bower install by @hubert [#129][]
 
-[#121]: https://github.com/42dev/bower-rails/pull/129
+[#129]: https://github.com/42dev/bower-rails/pull/129
 
 ## v0.9.2
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ BowerRails.configure do |bower_rails|
 
   # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
   bower_rails.use_bower_install_deployment = true
+
+  # Passes the -F option to rake bower:install or rake bower:install:deployment. Defaults to false.
+  bower_rails.force_install = true
 end
 ```
 

--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -26,6 +26,10 @@ module BowerRails
     # instead of rake bower:install before assets precompilation
     attr_accessor :use_bower_install_deployment
 
+    # If set to true then rake bower:install[-f] will be invoked
+    # instead of rake bower:install before assets precompilation
+    attr_accessor :force_install
+
     def configure &block
       yield self if block_given?
       collect_tasks
@@ -36,6 +40,7 @@ module BowerRails
       def collect_tasks
         install_cmd = 'bower:install'
         install_cmd = 'bower:install:deployment' if @use_bower_install_deployment
+        install_cmd += '[-F]' if @force_install
 
         @tasks << [install_cmd] if @install_before_precompile
         @tasks << [install_cmd, 'bower:clean']   if @clean_before_precompile
@@ -53,4 +58,5 @@ module BowerRails
   @resolve_before_precompile    = false
   @clean_before_precompile      = false
   @use_bower_install_deployment = false
+  @force_install = false
 end

--- a/lib/generators/bower_rails/initialize/templates/bower_rails.rb
+++ b/lib/generators/bower_rails/initialize/templates/bower_rails.rb
@@ -13,4 +13,7 @@ BowerRails.configure do |bower_rails|
 
   # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
   # bower_rails.use_bower_install_deployment = true
+  #
+  # Invokes rake bower:install and rake bower:install:deployment with -F (force) flag. Defaults to false
+  # bower_rails.force_install = true
 end

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -86,7 +86,7 @@ namespace :bower do
 
   task :before_precompile do
     BowerRails.tasks.each do |task|
-      Rake::Task[task].invoke
+      Rake.application.invoke_task(task)
     end
   end
 end

--- a/spec/bower-rails/bower-rails_spec.rb
+++ b/spec/bower-rails/bower-rails_spec.rb
@@ -102,5 +102,24 @@ describe BowerRails do
         expect(BowerRails.tasks.size).to eq(3)
       end
     end
+
+    describe '#force_install' do
+      it 'calls bower install with -f' do
+        BowerRails.configure do |bower_rails|
+          bower_rails.force_install = true
+          bower_rails.install_before_precompile = true
+        end
+        expect(BowerRails.tasks).to include('bower:install[-F]')
+      end
+
+      it 'calls bower install deployement with -f' do
+        BowerRails.configure do |bower_rails|
+          bower_rails.force_install = true
+          bower_rails.use_bower_install_deployment = true
+          bower_rails.install_before_precompile = true
+        end
+        expect(BowerRails.tasks).to include('bower:install:deployment[-F]')
+      end
+    end
   end
 end


### PR DESCRIPTION
Two changes:

- adds an option to configure bower to force install
- modifies how rake task is invoked in order to ease passing of options