### PR TITLE
Removes syntax error about the main_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ asset "moment", "2.10.1", main_files: ["./locale/en-gb.js"]
 
 # or in block
 asset "moment", "2.10.1" do
-  main_files: [
+  main_files [
     "./locale/en-gb.js",
     "./locale/fr.js",
     "./locale/lv.js"


### PR DESCRIPTION
When using the syntax on the README, `rake bower:install` doesn't run:
```ruby
asset "moment", "2.10.1" do
  main_files: [
    "./locale/en-gb.js",
    "./locale/fr.js",
    "./locale/lv.js"
  ]
end
```

by removing the colon everything works.