### PR TITLE
Fix readme capistrano documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,15 +266,17 @@ rake bower:install['-f']
 While using Capistrano 3 and Capistrano Rails gem, it's needed to run bower install before assets compile. Add the following code to your deploy.rb, it will run `rake bower:install` before compiling the assets. CI=true flag is used not to ask for the analytics at the first bower install.
 
 ```
-desc "Install bower"
-task :install_bower do
-  on roles(:web) do
-    within release_path do
-      execute :rake, 'bower:install CI=true'
+namespace :bower do
+  desc 'Install bower'
+  task :install do
+    on roles(:web) do
+      within release_path do
+        execute :rake, 'bower:install CI=true'
+      end
     end
   end
 end
-before "deploy:compile_assets", "deploy:install_bower"
+before 'deploy:compile_assets', 'bower:install'
 ```
 
 ##Bower Configuration


### PR DESCRIPTION
Task `bower_install` namespace was missing