### PR TITLE
Allow myself to overwrite the hard coded bower_components directory

### DIFF
--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -30,6 +30,9 @@ module BowerRails
     # instead of rake bower:install before assets precompilation
     attr_accessor :force_install
 
+    # Where to store the bower components
+    attr_accessor :bower_components_directory
+
     def configure &block
       yield self if block_given?
       collect_tasks

--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -66,10 +66,9 @@ module BowerRails
       txt  = File.read(File.join(root_path, "bower.json"))
       json = JSON.parse(txt)
 
-
       # Load and merge root .bowerrc
       dot_bowerrc = JSON.parse(File.read(File.join(root_path, '.bowerrc'))) rescue {}
-      dot_bowerrc["directory"] = "bower_components"
+      dot_bowerrc["directory"] = BowerRails.bower_components_directory || "bower_components"
 
       if json.except('lib', 'vendor').empty?
         folders = json.keys


### PR DESCRIPTION
What do you think of this as a temporary solution to #143 ?

I thought about making it cleaner, allowing people to specify the full path, removing the unnecessary lib/vendor options etc, but it lead down a rabbit hole that required rewriting many things.

This solves my immediate problem (wanting to store assets in `vendor/assets/bower/vendor`) without changing too many other things.