### PR TITLE
Add check pending feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ BowerRails.configure do |bower_rails|
 
   # Passes the -F option to rake bower:install or rake bower:install:deployment. Defaults to false.
   bower_rails.force_install = true
+
+  # Raises exception if bower install needs to be run. Defaults to false
+  bower_rails.check_pending = true
 end
 ```
 

--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -30,6 +30,10 @@ module BowerRails
     # instead of rake bower:install before assets precompilation
     attr_accessor :force_install
 
+    # If set to true then it checks whether the bowerfile
+    # has been updated after last bower install
+    attr_accessor :check_pending
+
     def configure &block
       yield self if block_given?
       collect_tasks
@@ -58,5 +62,6 @@ module BowerRails
   @resolve_before_precompile    = false
   @clean_before_precompile      = false
   @use_bower_install_deployment = false
-  @force_install = false
+  @force_install                = false
+  @check_pending                = false
 end

--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -10,6 +10,10 @@ module BowerRails
       new.perform(*args, &block)
     end
 
+    def self.check_pending!
+      new.check_pending!
+    end
+
     def root_path
       BowerRails.root_path
     end
@@ -176,6 +180,16 @@ module BowerRails
             FileUtils.rm(file_or_dir)
           end
         end
+      end
+    end
+
+    def check_pending!
+      bowerfile_mtime = File.mtime(File.join(root_path, "Bowerfile")).to_i
+      bower_json_mtime = File.mtime(File.join(root_path, "vendor", "assets", "bower.json")).to_i rescue 0
+
+      if bowerfile_mtime > bower_json_mtime
+        raise LoadError,
+              "Bowerfile has been updated after last bower install. Run rake bower:install to load latest packages."
       end
     end
 

--- a/lib/bower-rails/railtie.rb
+++ b/lib/bower-rails/railtie.rb
@@ -1,5 +1,6 @@
 require 'bower-rails'
 require 'bower-rails/dsl'
+require 'bower-rails/performer'
 require 'rails'
 
 module BowerRails
@@ -20,6 +21,10 @@ module BowerRails
           app.config.assets.paths << Rails.root.join(dir, 'assets', 'bower_components')
         end
       end
+    end
+
+    config.after_initialize do
+      BowerRails::Performer.check_pending! if BowerRails.check_pending
     end
 
     rake_tasks do

--- a/lib/generators/bower_rails/initialize/templates/bower_rails.rb
+++ b/lib/generators/bower_rails/initialize/templates/bower_rails.rb
@@ -16,4 +16,7 @@ BowerRails.configure do |bower_rails|
   #
   # Invokes rake bower:install and rake bower:install:deployment with -F (force) flag. Defaults to false
   # bower_rails.force_install = true
+
+  # Raises exception if bower install needs to be run. Defaults to false
+  # bower_rails.check_pending = true
 end


### PR DESCRIPTION
Add check pending feature. If the Bowerfile's modification time is newer than bower.json file then it means that bower.json needs to be updated via using rake bower:install. Raises an exception after rails initialization if the flag is set to true.

It's especially useful when a team is working on the same project and Bowerfile is changing frequently.

ActiveRecord's check pending migrations mechanism has been taken as reference.