### PR TITLE
Safer way of removing previous components

### DIFF
--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -91,7 +91,7 @@ module BowerRails
         Dir.chdir(dir) do
 
           # Remove old components
-          FileUtils.rm_rf("bower_components") if remove_components
+          FileUtils.rm_rf("bower_components/*") if remove_components
 
           # Create bower.json
           File.open("bower.json", "w") do |f|


### PR DESCRIPTION
If `vendor/assets/bower_components` is a symlink then running `rake bower:install:production` will break it.
It is better to remove `bower_components` contents but not `bower_components` itself. 