### PR TITLE
Load Bowerfile from all gem dependencies before load

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ BowerRails.configure do |bower_rails|
   # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
   bower_rails.use_bower_install_deployment = true
 
+  # rake bower:install will search for gem dependencies and in each gem it will search for Bowerfile
+  # and then concatenate all Bowerfile for evaluation
+  bower_rails.use_gem_deps_for_bowerfile = true
+
   # Passes the -F option to rake bower:install or rake bower:install:deployment. Defaults to false.
   bower_rails.force_install = true
 end

--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -26,6 +26,11 @@ module BowerRails
     # instead of rake bower:install before assets precompilation
     attr_accessor :use_bower_install_deployment
 
+    # If set to true then rake bower:install will search for gem dependencies
+    # and in each gem it will search for Bowerfile and then concatenate all Bowerfile
+    # for evaluation
+    attr_accessor :use_gem_deps_for_bowerfile
+
     # If set to true then rake bower:install[-f] will be invoked
     # instead of rake bower:install before assets precompilation
     attr_accessor :force_install
@@ -58,5 +63,6 @@ module BowerRails
   @resolve_before_precompile    = false
   @clean_before_precompile      = false
   @use_bower_install_deployment = false
+  @use_gem_deps_for_bowerfile   = false
   @force_install = false
 end


### PR DESCRIPTION
I faced the same limitation as discussed in #133, so implemented an easy solution by checking all gem dependencies for a Bowerfile.
If one found then it is evaluated before the main Bowerfile of the project what you are working on.
It works like all definitions would be in the same Bowerfile. Maybe it's not the ideal solution, but at least it works.