### PR TITLE
Adds clean component ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ BowerRails.configure do |bower_rails|
 
   # Invokes rake bower:clean before precompilation. Defaults to false
   bower_rails.clean_before_precompile = true
+  
+  # Excludes specific bower components from clean. Defaults to nil
+  bower_rails.exclude_from_clean = ['moment']
 
   # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
   bower_rails.use_bower_install_deployment = true

--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -22,6 +22,10 @@ module BowerRails
     # are invoked before assets precompilation
     attr_accessor :clean_before_precompile
 
+    # If containing a list of bower component names, those components
+    # will be excluded from the bower:clean
+    attr_accessor :exclude_from_clean
+
     # If set to true then rake bower:install:deployment will be invoked
     # instead of rake bower:install before assets precompilation
     attr_accessor :use_bower_install_deployment

--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -147,6 +147,9 @@ module BowerRails
       puts "\nAttempting to remove all but main files as specified by bower\n"
 
       Dir['bower_components/*'].each do |component_dir|
+        component_name = component_dir.split('/').last
+        next if clean_should_skip_component? component_name
+
         if File.exists?(File.join(component_dir, 'bower.json'))
           bower_file = File.read(File.join(component_dir, 'bower.json'))
         elsif File.exists?(File.join(component_dir, '.bower.json'))
@@ -157,7 +160,6 @@ module BowerRails
 
         # Parse bower.json
         bower_json = JSON.parse(bower_file)
-        component_name = component_dir.split('/').last
         main_files = Array(bower_json['main']) + main_files_for_component(component_name)
         next if main_files.empty?
 
@@ -196,6 +198,11 @@ module BowerRails
 
     def main_files_for_component(name)
       Array(dsl.main_files[name])
+    end
+
+    def clean_should_skip_component?(name)
+      BowerRails.exclude_from_clean.respond_to?(:include?) &&
+        BowerRails.exclude_from_clean.include?(name)
     end
   end
 end

--- a/spec/bower-rails/bower-rails_spec.rb
+++ b/spec/bower-rails/bower-rails_spec.rb
@@ -17,6 +17,10 @@ describe BowerRails do
     expect(BowerRails.clean_before_precompile).to eq(false)
   end
 
+  it 'should not set default value for exclude_from_clean option' do
+    expect(BowerRails.exclude_from_clean).to be_nil
+  end
+
   it 'should set default value for @tasks option' do
     expect(BowerRails.instance_variable_get(:@tasks)).to be_empty
   end
@@ -29,6 +33,7 @@ describe BowerRails do
         bower_rails.install_before_precompile = false
         bower_rails.resolve_before_precompile = false
         bower_rails.clean_before_precompile = false
+        bower_rails.exclude_from_clean = ['foo-component']
       end
     end
 
@@ -83,6 +88,18 @@ describe BowerRails do
 
       it 'should form correct tasks for enhancing assets:precompile' do
         expect(BowerRails.tasks).to eq(['bower:install', 'bower:clean'])
+      end
+    end
+
+    describe '#exclude_from_clean' do
+      before do
+        BowerRails.configure do |bower_rails|
+          bower_rails.exclude_from_clean = ['moment']
+        end
+      end
+
+      it 'should set exclude_from_clean option' do
+        expect(BowerRails.exclude_from_clean).to eq ['moment']
       end
     end
 

--- a/spec/bower-rails/performer_spec.rb
+++ b/spec/bower-rails/performer_spec.rb
@@ -6,6 +6,7 @@ describe BowerRails::Performer do
 
   let(:performer) { BowerRails::Performer.new }
   let(:main_files) { {} }
+  let(:exempt_list) { nil }
 
   context "remove_extra_files" do
     let(:root) { File.expand_path('../../..', __FILE__) }
@@ -45,6 +46,9 @@ describe BowerRails::Performer do
 
       Dir.chdir("#{root}/tmp")
 
+      # Stub exclude from clean setting
+      BowerRails.exclude_from_clean = exempt_list
+
       performer.perform false do
         remove_extra_files
       end
@@ -78,6 +82,26 @@ describe BowerRails::Performer do
       let(:main_files) { { 'moment' => ['./moment_plugin.js'] } }
 
       it "keeps moment_plugin.js" do
+        expect(File).to exist("#{root}/tmp/vendor/assets/bower_components/moment/moment_plugin.js")
+      end
+    end
+
+    context 'with moment exempt from clean' do
+      let(:exempt_list) { ['moment'] }
+
+      it 'keeps bower.json' do
+        expect(File).to exist("#{root}/tmp/vendor/assets/bower_components/moment/bower.json")
+      end
+
+      it 'keeps unknown.file' do
+        expect(File).to exist("#{root}/tmp/vendor/assets/bower_components/moment/unknown.file")
+      end
+
+      it 'keeps unknown_dir' do
+        expect(File).to exist("#{root}/tmp/vendor/assets/bower_components/moment/unknown_dir")
+      end
+
+      it 'keeps moment_plugin.js' do
         expect(File).to exist("#{root}/tmp/vendor/assets/bower_components/moment/moment_plugin.js")
       end
     end


### PR DESCRIPTION
Allows for a list of bower components to be exempt from the clean. 

```
BowerRails.configure do |bower_rails|
  bower_rails.clean_before_precompile = true
  bower_rails.exclude_from_clean = ['moment']
end
```

Another option might be to implement something like as suggested in https://github.com/rharriso/bower-rails/issues/160 but for the one package where I needed something outside of the main, this seemed suitable.


