### PR TITLE
Option to overwrite the hard coded bower_components directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Edge version
 
 * Load Bowerfile from all gem dependencies before load by @gabealmer [#162][]
+* Make bower components directory configurable [#183][]
 
 [#162]: https://github.com/rharriso/bower-rails/pull/162
+[#183]: https://github.com/rharriso/bower-rails/pull/183
 
 ## v0.10.0
 

--- a/lib/bower-rails.rb
+++ b/lib/bower-rails.rb
@@ -39,6 +39,9 @@ module BowerRails
     # instead of rake bower:install before assets precompilation
     attr_accessor :force_install
 
+    # Where to store the bower components
+    attr_accessor :bower_components_directory
+
     def configure &block
       yield self if block_given?
       collect_tasks
@@ -69,4 +72,5 @@ module BowerRails
   @use_bower_install_deployment = false
   @use_gem_deps_for_bowerfile   = false
   @force_install = false
+  @bower_components_directory = "bower_components"
 end

--- a/lib/bower-rails/railtie.rb
+++ b/lib/bower-rails/railtie.rb
@@ -11,13 +11,15 @@ module BowerRails
       config.before_initialize do |app|
         @dsl = BowerRails::Dsl.evalute(BowerRails.root_path, @@bowerfile)
         @dsl.final_assets_path.map do |assets_root, assets_path|
-          app.config.assets.paths << Rails.root.join(assets_root, assets_path, "bower_components")
+          app.config.assets.paths <<
+            Rails.root.join(assets_root, assets_path, BowerRails.bower_components_directory)
         end
       end
     else
       config.before_initialize do |app|
         ["lib", "vendor"].each do |dir|
-          app.config.assets.paths << Rails.root.join(dir, 'assets', 'bower_components')
+          app.config.assets.paths <<
+            Rails.root.join(dir, 'assets', BowerRails.bower_components_directory)
         end
       end
     end

--- a/lib/generators/bower_rails/initialize/templates/bower_rails.rb
+++ b/lib/generators/bower_rails/initialize/templates/bower_rails.rb
@@ -16,4 +16,7 @@ BowerRails.configure do |bower_rails|
   #
   # Invokes rake bower:install and rake bower:install:deployment with -F (force) flag. Defaults to false
   # bower_rails.force_install = true
+
+  # Change the default directory name
+  # bower_rails.bower_components_directory = 'bower_components'
 end

--- a/lib/tasks/bower.rake
+++ b/lib/tasks/bower.rake
@@ -62,9 +62,10 @@ namespace :bower do
   end
 
   desc "Resolve assets paths in bower components"
-  task :resolve do
+  task :resolve, :relative_directory do |_, args|
     BowerRails::Performer.perform false do
-      resolve_asset_paths
+      resolve_asset_paths(
+        args[:relative_directory] || BowerRails.bower_components_directory)
     end
   end
 


### PR DESCRIPTION
This is meant to complete and replace https://github.com/rharriso/bower-rails/pull/146. As for testing, I consider it to have coverage since the test suite continues to test that the performer works, but it uses the default value of `BowerRails.bower_components_directory`.