### PR TITLE
Lock version of tins so that tests run on Ruby 1.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,7 @@ gem "rails", rails
 gem 'pry'
 
 gemspec
+
+group :test do
+  gem 'tins', '~> 1.6.0'
+end


### PR DESCRIPTION
coveralls depends on tins and tins >= 1.7 requires Ruby 2.0, hence the failing tests on CI.

See: https://github.com/elastic/logstash/issues/4163.