### PR TITLE
Fix finding correct path to bower in windows environment

### DIFF
--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -188,7 +188,7 @@ module BowerRails
       paths.each do |path|
         exts.each do |ext|
           exe = File.join(path, "#{cmd}#{ext}")
-          return exe if (File.executable?(exe) && File.file?(exe))
+          return exe.gsub(/^(.*\s+.*)$/,'\'\0\'') if (File.executable?(exe) && File.file?(exe))
         end
       end
       nil


### PR DESCRIPTION
Since the default location for bower is under "Program Files" in Windows, we've got something like
C:\Program Files\nodejs\bower.CMD update 
rake aborted!
Command failed with status (127): [C:\Program Files\nodejs\bower.CMD update ...]

It seems, adding single quotes is the simplest solution.
