### PR TITLE
Update Capistrano deploy command's sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ namespace :bower do
   task :install do
     on roles(:web) do
       within release_path do
-        execute :rake, 'bower:install CI=true'
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'bower:install CI=true'
+        end
       end
     end
   end


### PR DESCRIPTION
While using Capistrano 3 and Capistrano Rails gem, rake command should be used with rails_env.

If not, rake command will run in `:development` environment and fail in some case.

In my case, I was using [rails-flog](https://github.com/pinzolo/rails-flog) gem only `:development` environment, but the deployment failed at `execute :rake, 'bower:install CI=true'` because of requirements.
