### PR TITLE
Address ruby 23 issues: uninitialized ivar + circular requires

### DIFF
--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -26,6 +26,7 @@ module BowerRails
       @resolutions = {}
       @assets_path ||= "assets"
       @main_files = {}
+      @current_group = nil
     end
 
     def asset(name, *args, &block)

--- a/lib/bower-rails/railtie.rb
+++ b/lib/bower-rails/railtie.rb
@@ -1,6 +1,4 @@
-require 'bower-rails'
 require 'bower-rails/dsl'
-require 'rails'
 
 module BowerRails
   class Railtie < Rails::Railtie


### PR DESCRIPTION
This does two things:

* initialize `@current_group` in `dsl.rb` so that Ruby won't complain about it not having a value before being used.
* remove the circular `require` between `bower-rails.rb` and `railtie.rb`.  My assumption is that the `require` of the railtie inside `bower-rails.rb` is more important and more intentional so I left that and removed the `require` of `bower-rails` from the railtie.  Please let me know if there's a better way to address this.