### PR TITLE
Shell-escape bower commmand to handle directories with spaces

### DIFF
--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -186,7 +186,9 @@ module BowerRails
       paths.each do |path|
         exts.each do |ext|
           exe = File.join(path, "#{cmd}#{ext}")
-          return exe if (File.executable?(exe) && File.file?(exe))
+          if (File.executable?(exe) && File.file?(exe))
+            return Shellwords.escape exe
+          end
         end
       end
       nil


### PR DESCRIPTION
Rake tasks previously failed if the bower executable existed in a
directory that had spaces.