### PR TITLE
Fail rake task when bower isn't installed

### DIFF
--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -22,7 +22,7 @@ module BowerRails
         $stderr.puts ["Bower not found! You can install Bower using Node and npm:",
         "$ npm install bower -g",
         "For more info see http://bower.io/"].join("\n")
-        return
+        exit 127
       end
 
       if entries.include?('Bowerfile')


### PR DESCRIPTION
Adding the correct exit code 127 on failure to locate 'bower'

Re: #168 can now check status code in deploy scripts; 0 for pass, 127 for 'command not found'