### PR TITLE
Put url parameters outside of erb on paths resolve

### DIFF
--- a/lib/bower-rails/performer.rb
+++ b/lib/bower-rails/performer.rb
@@ -118,7 +118,7 @@ module BowerRails
       Dir["#{components_directory}/**/*.css"].each do |filename|
         contents = File.read(filename) if FileTest.file?(filename)
         # http://www.w3.org/TR/CSS2/syndata.html#uri
-        url_regex = /url\((?!\#)\s*['"]?(?![a-z]+:)([^'"\)]*)['"]?\s*\)/
+        url_regex = /url\((?!\#)\s*['"]?((?![a-z]+:)([^'"\)]*?)([?#][^'"\)]*)?)['"]?\s*\)/
 
         # Resolve paths in CSS file if it contains a url
         if contents =~ url_regex
@@ -127,11 +127,12 @@ module BowerRails
 
           # Replace relative paths in URLs with Rails asset_path helper
           new_contents = contents.gsub(url_regex) do |match|
-            relative_path = $1
+            relative_path = $2
+            params = $3
             image_path = directory_path.join(relative_path).cleanpath
-            puts "#{match} => #{image_path}"
+            puts "#{match} => #{image_path} #{params}"
 
-            "url(<%= asset_path '#{image_path}' %>)"
+            "url(<%= asset_path '#{image_path}' %>#{params})"
           end
 
           # Replace CSS with ERB CSS file with resolved asset paths

--- a/spec/bower-rails/performer_spec.rb
+++ b/spec/bower-rails/performer_spec.rb
@@ -3,25 +3,40 @@ require 'bower-rails/performer'
 require 'pry'
 
 describe BowerRails::Performer do
-
   let(:performer) { BowerRails::Performer.new }
   let(:main_files) { {} }
   let(:exempt_list) { nil }
+  let(:root) { File.expand_path('../../..', __FILE__) }
+  let(:tmp_dir) { File.join root, "tmp" }
+  let(:files_dir) { File.join root, "spec", "files" }
+  let(:create_bower_file) { true }
 
-  context "remove_extra_files" do
-    let(:root) { File.expand_path('../../..', __FILE__) }
-    let(:create_bower_file) { true }
+  before do
+    # `rm -rf ./tmp` remove temporary directory
+    FileUtils.rm_rf("#{root}/tmp")
 
+    # setup temporary directory
+    FileUtils.mkdir("#{root}/tmp")
+    FileUtils.cp("#{root}/spec/files/Bowerfile", "#{root}/tmp/Bowerfile") if create_bower_file
+    FileUtils.cp("#{root}/spec/files/bower.json", "#{root}/tmp/bower.json")
+
+    # points `root_path` to temporary directory
+    allow(performer).to receive(:root_path) { "#{root}/tmp" }
+
+    # trick BowerRails that system has bower installed
+    allow(performer).to receive(:find_command) { "bower" }
+
+    # sets main_files in DSL
+    allow_any_instance_of(BowerRails::Dsl).to receive(:main_files){ main_files }
+
+    Dir.chdir("#{root}/tmp")
+
+    # Stub exclude from clean setting
+    BowerRails.exclude_from_clean = exempt_list
+  end
+
+  describe "remove_extra_files" do
     before do
-      # `rm -rf ./tmp` remove temporary directory
-      FileUtils.rm_rf("#{root}/tmp")
-
-      # setup temporary directory
-      FileUtils.mkdir("#{root}/tmp")
-      FileUtils.cp("#{root}/spec/files/Bowerfile", "#{root}/tmp/Bowerfile") if create_bower_file
-      FileUtils.cp("#{root}/spec/files/bower.json", "#{root}/tmp/bower.json")
-
-
       FileUtils.mkdir_p("#{root}/tmp/vendor/assets/bower_components")
 
       # creates bower library
@@ -37,20 +52,6 @@ describe BowerRails::Performer do
       File.open("#{root}/tmp/vendor/assets/bower_components/moment/bower.json", "w") do |f|
         f.write(%q({"name":"moment","main":["./moment.js", "./fonts/*"]}))
       end
-
-      # points `root_path` to temporary directory
-      allow(performer).to receive(:root_path) { "#{root}/tmp" }
-
-      # trick BowerRails that system has bower installed
-      allow(performer).to receive(:find_command) { "bower" }
-
-      # sets main_files in DSL
-      allow_any_instance_of(BowerRails::Dsl).to receive(:main_files){ main_files }
-
-      Dir.chdir("#{root}/tmp")
-
-      # Stub exclude from clean setting
-      BowerRails.exclude_from_clean = exempt_list
 
       performer.perform false do
         remove_extra_files
@@ -138,4 +139,44 @@ describe BowerRails::Performer do
     end
   end
 
+  describe "resolve_asset_paths" do
+    let(:target_path) { "#{tmp_dir}/vendor/assets/bower_components/foobar/style.css" }
+
+    before do
+      FileUtils.mkdir_p(File.dirname(target_path))
+      FileUtils.cp("#{files_dir}/style.css", target_path)
+
+      performer.perform false do
+        resolve_asset_paths
+      end
+    end
+
+    it "removes .css file" do
+      expect(File).to_not exist(target_path)
+    end
+
+    it "creates .css.erb file" do
+      expect(File).to exist("#{target_path}.erb")
+    end
+
+    describe "created .erb file" do
+      subject { File.read "#{target_path}.erb" }
+
+      it "includes proper asset paths" do
+        expect(subject).to include "<%= asset_path 'foobar.png' %>"
+      end
+
+      it "does not include improper asset paths" do
+        expect(subject).not_to match(/<%= asset_path 'foobar.png[?#]/)
+      end
+
+      it "pushes url params after the erb block" do
+        expect(subject).to include "<%= asset_path 'foobar.png' %>?"
+      end
+
+      it "pushes url anchor after the erb block" do
+        expect(subject).to include "<%= asset_path 'foobar.png' %>#"
+      end
+    end
+  end
 end

--- a/spec/files/style.css
+++ b/spec/files/style.css
@@ -1,0 +1,16 @@
+body {
+  background: url('../foobar.png')
+}
+
+.param {
+  background: url("../foobar.png?foo=true")
+}
+
+.anchor {
+  background: url(../foobar.png#foo)
+}
+
+.param.anchor {
+  background: url("../foobar.png#foo?foo=true#foo")
+}
+


### PR DESCRIPTION
Original problem was with `fontawesome`, with `rake bower:resolve`, bower-rails was generating urls like
```sass
  src: url(<%= asset_path 'fontawesome/fonts/fontawesome-webfont.eot?v=4.4.0' %>);
```
And when we tried to manually compile assets from code in production - Rails was trying to fetch that exact string from `assets.digest` instead of just `'fontawesome/fonts/fontawesome-webfont.eot'` - and we were getting `AssetNotPrecompiledError`
Essentially this PR just changes `bower-rails` to generate such urls as
```sass
  src: url(<%= asset_path 'fontawesome/fonts/fontawesome-webfont.eot' %>?v=4.4.0);
```