### PR TITLE
Use https for github sources (github deprecated insecure git)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Egde version
+## Edge version
 
-Nothing pushed yet
+* Use https for github sources (github deprecated insecure git) by @abrom [#218][]
+
+[#218]: https://github.com/rharriso/bower-rails/pull/218 
 
 ## v0.11.0
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ dependency_group :dev_dependencies  do
   asset "jasmine-matchers"         # Defaults to 'latest'
 end
 
-# Explicit dependency group notation ( not neccessary )
+# Explicit dependency group notation ( not necessary )
 dependency_group :dependencies  do
   asset "emberjs"                  # Defaults to 'latest'
 end

--- a/lib/bower-rails/dsl.rb
+++ b/lib/bower-rails/dsl.rb
@@ -37,7 +37,7 @@ module BowerRails
       version = args.last || "latest"
       version = options[:ref] if options[:ref]
 
-      options[:git] = "git://github.com/#{options[:github]}" if options[:github]
+      options[:git] = "https://github.com/#{options[:github]}.git" if options[:github]
 
       if options[:git]
         version = if version == 'latest'

--- a/spec/bower-rails/dsl_spec.rb
+++ b/spec/bower-rails/dsl_spec.rb
@@ -87,12 +87,12 @@ describe BowerRails::Dsl do
 
     it "should accept a github path" do
       subject.asset :new_hotness, :github => "initech/tps-kit"
-      subject.dependencies.values.should include :dependencies => {:new_hotness => "git://github.com/initech/tps-kit"}
+      subject.dependencies.values.should include :dependencies => {:new_hotness => "https://github.com/initech/tps-kit.git"}
     end
 
     it "should accept a github path and a version and put it all together" do
       subject.asset :new_hotness, "1.2.3", :github => "initech/tps-kit"
-      subject.dependencies.values.should include :dependencies => {:new_hotness => "git://github.com/initech/tps-kit#1.2.3"}
+      subject.dependencies.values.should include :dependencies => {:new_hotness => "https://github.com/initech/tps-kit.git#1.2.3"}
     end
 
     it "should accept a ref option and set it as a version" do
@@ -107,7 +107,7 @@ describe BowerRails::Dsl do
 
     it "should accept a github and ref option and put it all together" do
       subject.asset :new_hotness, :github => "initech/tps-kit", :ref => "b122a"
-      subject.dependencies.values.should include :dependencies => {:new_hotness => "git://github.com/initech/tps-kit#b122a"}
+      subject.dependencies.values.should include :dependencies => {:new_hotness => "https://github.com/initech/tps-kit.git#b122a"}
     end
 
     it "should accept a main_files option and put it all together" do
@@ -121,7 +121,6 @@ describe BowerRails::Dsl do
       end
       subject.main_files.should eq(new_hotness: ['dist/foo.js'])
     end
-
   end
 
   it "should have a private method to validate asset paths" do


### PR DESCRIPTION
Github have recently dropped support for fetching sources using the `git` protocol (port 9418) in a bid to prevent MITM issues.

Subsequently trying to fetch a source defined with the `github` option will result in:

```
10:27:06  bower mypackage#master                             ECMDERR Failed to execute "git ls-remote --tags --heads git://github.com/user/mypackage.git", exit code of #128 fatal: remote error:    The unauthenticated git protocol on port 9418 is no longer supported. Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
10:27:06  
10:27:06  Additional error details:
10:27:06  fatal: remote error: 
10:27:06    The unauthenticated git protocol on port 9418 is no longer supported.
10:27:06  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
10:27:06  rake aborted!
```

This change swaps out the insecure `git` protocol for `https` in the DSL parsing.

Note of course that this would still allow someone to specify the `git` protocol using the `git` option, however given this issue is only specific to Github, that would seem perfectly reasonable.

This *could* do with some sort of explanation in the README, however it very much comes down to how the git content is hosted so very likely outside the scope of this project